### PR TITLE
Fixed formatting and excluded fields  @EqualsAndHashCode @ToString Adnotations in @Entity classes

### DIFF
--- a/src/main/java/pl/on/full/hack/auth/entity/RankrUser.java
+++ b/src/main/java/pl/on/full/hack/auth/entity/RankrUser.java
@@ -1,8 +1,6 @@
 package pl.on.full.hack.auth.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import pl.on.full.hack.match.entity.Match;
 import pl.on.full.hack.league.entity.League;
 import pl.on.full.hack.league.entity.LeaguePlayer;
@@ -16,6 +14,8 @@ import java.util.Set;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode(exclude={"createdLeagues", "matches", "leaguePlayer"})
+@ToString(exclude={"createdLeagues", "matches", "leaguePlayer"})
 public class RankrUser {
 
     @Id

--- a/src/main/java/pl/on/full/hack/league/entity/League.java
+++ b/src/main/java/pl/on/full/hack/league/entity/League.java
@@ -1,6 +1,8 @@
 package pl.on.full.hack.league.entity;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import pl.on.full.hack.auth.entity.RankrUser;
 import pl.on.full.hack.base.utils.MappingUtil;
 import pl.on.full.hack.match.entity.Match;
@@ -15,6 +17,8 @@ import java.util.Set;
 @Entity
 @Table(name = "leagues")
 @Data
+@EqualsAndHashCode(exclude={"matches", "leaguePlayers"})
+@ToString(exclude={"matches", "leaguePlayers"})
 public class League {
 
     @Id
@@ -42,6 +46,11 @@ public class League {
     public LeagueDetailsDTO getDetailsDTO() {
         final LeagueDetailsDTO leagueDetailsDTO = new LeagueDetailsDTO();
         leagueDetailsDTO.setMatches(MappingUtil.mapCollection(this.getMatches(), MatchDTO.class));
+//        leagueDetailsDTO.setPlayers(new ArrayList<LeaguePlayerDTO>());
+//        TODO:: Fix setPlayers
+        System.out.println(this.getLeaguePlayers().isEmpty());
+        System.out.println(this.getLeaguePlayers().toArray().length);
+        System.out.println(this.getLeaguePlayers().toString());
         leagueDetailsDTO.setPlayers(MappingUtil.mapCollection(this.getLeaguePlayers(), LeaguePlayerDTO.class));
         leagueDetailsDTO.setDiscipline(getDiscipline());
         leagueDetailsDTO.setName(getName());

--- a/src/main/java/pl/on/full/hack/league/entity/LeaguePlayer.java
+++ b/src/main/java/pl/on/full/hack/league/entity/LeaguePlayer.java
@@ -2,6 +2,7 @@ package pl.on.full.hack.league.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import pl.on.full.hack.auth.entity.RankrUser;
 

--- a/src/main/java/pl/on/full/hack/league/service/LeagueService.java
+++ b/src/main/java/pl/on/full/hack/league/service/LeagueService.java
@@ -46,7 +46,6 @@ public class LeagueService {
         final Optional<League> leagueOptional = repository.findById(id);
         final League league = leagueOptional
                 .orElseThrow(() -> new NotFoundException("No league with id " + id));
-
         return league.getDetailsDTO();
     }
 
@@ -63,7 +62,6 @@ public class LeagueService {
     }
 
     public void updateLeague(@NonNull LeagueDTO leagueDTO, final String username) throws NotFoundException, UnauthorizedException {
-        ;
         final Optional<League> leagueOptional = repository.findById(leagueDTO.getId());
         final League league = leagueOptional
                 .orElseThrow(() -> new NotFoundException("No league with id " + leagueDTO.getId()));

--- a/src/main/java/pl/on/full/hack/match/entity/Match.java
+++ b/src/main/java/pl/on/full/hack/match/entity/Match.java
@@ -1,6 +1,8 @@
 package pl.on.full.hack.match.entity;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import pl.on.full.hack.auth.entity.RankrUser;
 import pl.on.full.hack.db.Venue;
 import pl.on.full.hack.league.dto.MatchDTO;
@@ -13,6 +15,8 @@ import java.util.Set;
 @Entity
 @Table(name = "matches")
 @Data
+@EqualsAndHashCode(exclude={"players"})
+@ToString(exclude={"players"})
 public class Match {
 
     @Id


### PR DESCRIPTION
Taken from ```https://stackoverflow.com/questions/33234546/spring-boot-jpa-onetomany-relationship-causes-infinite-loop```:
```
As the first answer suggests:

Do not use Lombok's @Data annotation on @Entity classes.

Reason: @Data generates hashcode(), equals() and toString() methods that use the generated getters. Using the getter means of course fetching new data even if the property was marked with FetchType=LAZY.

Somewhere along the way hibernate tries to log the data with toString() and it crashes.

```